### PR TITLE
[FIX JENKINS-35137] EventSource reconnect killing old EvenDispatcher and losing channel subs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/sse-gateway",
-  "version": "0.0.3-beta1",
+  "version": "0.0.3",
   "description": "Client API for the Jenkins SSE Gateway plugin. Browser UI push events from Jenkins.",
   "main": "src/main/js/index.js",
   "files" : [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/sse-gateway",
-  "version": "0.0.2",
+  "version": "0.0.3-beta1",
   "description": "Client API for the Jenkins SSE Gateway plugin. Browser UI push events from Jenkins.",
   "main": "src/main/js/index.js",
   "files" : [

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
@@ -64,7 +64,7 @@ public abstract class EventDispatcher implements Serializable {
     public static final String SESSION_SYNC_OBJ = "org.jenkinsci.plugins.ssegateway.sse.session.sync";
     private static final Logger LOGGER = Logger.getLogger(EventDispatcher.class.getName());
 
-    private final String id = UUID.randomUUID().toString();
+    private String id = null;
     private final PubsubBus bus;
     private Map<EventFilter, ChannelSubscriber> subscribers = new CopyOnWriteMap.Hash<>();
 
@@ -80,7 +80,14 @@ public abstract class EventDispatcher implements Serializable {
     }
 
     public final String getId() {
+        if (id == null) {
+            throw new IllegalStateException("Call to getId before the ID ewas set.");
+        }
         return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     public boolean dispatchEvent(String name, String data) throws IOException, ServletException {

--- a/src/main/js/ajax.js
+++ b/src/main/js/ajax.js
@@ -1,5 +1,41 @@
 var json = require('./json');
 
+exports.get = function (url, onSuccess) {
+    var http = new XMLHttpRequest();
+
+    http.onreadystatechange = function () {
+        if (http.readyState === 4) {
+            if (http.status >= 200 && http.status < 300) {
+                try {
+                    var responseJSON = JSON.parse(http.responseText);
+                    // The request may have succeeded, but there might have been
+                    // some processing error on the backend and a hudson.util.HttpResponses
+                    // JSON response.
+                    if (responseJSON.status && responseJSON.status === 'error') {
+                        console.error('SSE Gateway error response to '
+                            + url + ': '
+                            + responseJSON.message);
+                    }
+
+                    if (onSuccess) {
+                        onSuccess(responseJSON);
+                    }
+                } catch (e) {
+                    // Not a JSON response.
+                }
+            } else {
+                console.error('SSE Gateway error to ' + url + ': ');
+                console.error(http);
+            }
+        }
+    };
+
+    http.open('GET', url, true);
+
+    http.setRequestHeader('Accept', 'application/json');
+    http.send();
+};
+
 exports.post = function (data, toUrl, jenkinsSessionInfo) {
     var http = new XMLHttpRequest();
 

--- a/src/main/js/index.js
+++ b/src/main/js/index.js
@@ -16,7 +16,13 @@ function noEventSource() {
 if (eventSourceSupported) {
     var internal = require('./sse-client');
 
-    internal.connect();
+    /**
+     * Connect the SSE client to the server..
+     * @param clientId The SSE client ID. This is a scrint but should be unique i.e. something
+     * not likely to clash with another SSE instance in the same session.
+     * @param onConnect Optionsal onConnect function.
+     */
+    exports.connect = internal.connect;
 
     /**
      * Subscribe to a channel.

--- a/src/test/js/sse-plugin-no-filter-ispec.js
+++ b/src/test/js/sse-plugin-no-filter-ispec.js
@@ -23,79 +23,79 @@ describe("sse plugin integration tests - subscribe and unsubscribe - no filters"
                 ajax.post(undefined, api.jenkinsUrl + 'job/sse-gateway-test-job/build', jenkinsSessionInfo);
             }
 
-            api.connect(function(jenkinsSession) {
+            api.connect('sse-client-123', function(jenkinsSession) {
                 jenkinsSessionInfo = jenkinsSession;
-            });
 
-            // Listen for sse events and use them to determine
-            // if subscribe/unsubscribe is working properly.
-            var sseEvents = [];
-            var subscribeCount = 0;
-            var unsubscribeCount = 0;
-            api.subscribe('sse', function (event) {
-                sseEvents.push(event);
-                if (event.jenkins_event === 'subscribe') {
-                    subscribeCount++;
-                } else if (event.jenkins_event === 'unsubscribe') {
-                    unsubscribeCount++;
-                }
-            });
-            
-            // jobsStarted should eventually equal number of jobs started i.e. 2
-            var jobsStarted = 0;
-            api.subscribe('job', function (event) {
-                // We actually wait for the end event before counting it.
-                // The jobSubs listener (below) uses the start event to count.
-                // This combo makes sure we are seeing thing in the right order.
-                if (event.jenkins_event === 'job_run_ended') {
-                    jobsStarted++;
-                }
-            });
-            
-            // jobSubsCalled should only hit 1 because we unsubscribe jobSubs 
-            // before starting the second job.
-            var jobSubsCalled = 0; 
-            var jobSubs = api.subscribe('job', function (event) {
-                if (event.jenkins_event === 'job_run_started') {
-                    // Test unsubscribe now by unsubscribing jobSubs.
-                    // See the waitUntil below.
-                    api.unsubscribe(jobSubs);
-
-                    jobSubsCalled++;
-
-                    // Run the second build
+                // Listen for sse events and use them to determine
+                // if subscribe/unsubscribe is working properly.
+                var sseEvents = [];
+                var subscribeCount = 0;
+                var unsubscribeCount = 0;
+                api.subscribe('sse', function (event) {
+                    sseEvents.push(event);
+                    if (event.jenkins_event === 'subscribe') {
+                        subscribeCount++;
+                    } else if (event.jenkins_event === 'unsubscribe') {
+                        unsubscribeCount++;
+                    }
+                });
+                
+                // jobsStarted should eventually equal number of jobs started i.e. 2
+                var jobsStarted = 0;
+                api.subscribe('job', function (event) {
+                    // We actually wait for the end event before counting it.
+                    // The jobSubs listener (below) uses the start event to count.
+                    // This combo makes sure we are seeing thing in the right order.
+                    if (event.jenkins_event === 'job_run_ended') {
+                        jobsStarted++;
+                    }
+                });
+                
+                // jobSubsCalled should only hit 1 because we unsubscribe jobSubs 
+                // before starting the second job.
+                var jobSubsCalled = 0; 
+                var jobSubs = api.subscribe('job', function (event) {
+                    if (event.jenkins_event === 'job_run_started') {
+                        // Test unsubscribe now by unsubscribing jobSubs.
+                        // See the waitUntil below.
+                        api.unsubscribe(jobSubs);
+    
+                        jobSubsCalled++;
+    
+                        // Run the second build
+                        runBuild();
+    
+                        // wait 60s for the second build and jobsStarted
+                        // to equal 2
+                        waitUntil(function () {
+                            return jobsStarted === 2;
+                        }, 60000).then(function() {
+                            // The check everything, especially that the unsubscribe worked
+                            // i.e. that this callback was not called again after.
+    
+                            // 3 subscribe events and 1 unsubscribe
+                            expect(sseEvents.length).toBe(4);
+                            expect(subscribeCount).toBe(3);
+                            expect(unsubscribeCount).toBe(1);
+    
+                            // jobSubsCalled should only be 1 because we unsubscribed 
+                            // jobSubs before calling runBuild the second time (see below).
+                            expect(jobsStarted).toBe(2);
+                            expect(jobSubsCalled).toBe(1);
+    
+                            api.disconnect();
+                            done();
+                        });
+                    }
+                });
+                
+                // Trigger the first build. This should trigger
+                // the SSE event listeners below.
+                waitUntil(function() {
+                    return (jenkinsSessionInfo !== undefined && subscribeCount === 3);
+                }, 60000).then(function() {
                     runBuild();
-
-                    // wait 60s for the second build and jobsStarted
-                    // to equal 2
-                    waitUntil(function () {
-                        return jobsStarted === 2;
-                    }, 60000).then(function() {
-                        // The check everything, especially that the unsubscribe worked
-                        // i.e. that this callback was not called again after.
-
-                        // 3 subscribe events and 1 unsubscribe
-                        expect(sseEvents.length).toBe(4);
-                        expect(subscribeCount).toBe(3);
-                        expect(unsubscribeCount).toBe(1);
-
-                        // jobSubsCalled should only be 1 because we unsubscribed 
-                        // jobSubs before calling runBuild the second time (see below).
-                        expect(jobsStarted).toBe(2);
-                        expect(jobSubsCalled).toBe(1);
-
-                        api.disconnect();
-                        done();
-                    });
-                }
-            });
-            
-            // Trigger the first build. This should trigger
-            // the SSE event listeners below.
-            waitUntil(function() {
-                return (jenkinsSessionInfo !== undefined && subscribeCount === 3);
-            }, 60000).then(function() {
-                runBuild();
+                });
             });
         });
     }, 60000);

--- a/src/test/js/sse-plugin-with-filter-ispec.js
+++ b/src/test/js/sse-plugin-with-filter-ispec.js
@@ -16,28 +16,28 @@ describe("sse plugin integration tests - with filters", function () {
 
             var api = jsTest.requireSrcModule('sse-client');
 
-            api.connect(function(jenkinsSessionInfo) {
+            api.connect('sse-client-123', function(jenkinsSessionInfo) {
                 var ajax = jsTest.requireSrcModule('ajax');
                 
                 // Once connected to the SSE Gateway, fire off a build of the sample job
                 ajax.post(undefined, api.jenkinsUrl + 'job/sse-gateway-test-job/build', jenkinsSessionInfo);
-            });
 
-            api.subscribe('job', function () {
-                expect('Should not have received this event').toBe();
-            }, {
-                job_name: 'xxxxx'
-            });
-
-            api.subscribe('job', function () {
-                // Wait a sec to give time for the unexpected event to arrive.
-                // It shouldn't arrive, but if it does, we throw an error. 
-                setTimeout(function() {
-                    api.disconnect();
-                    done();
-                }, 500);
-            }, {
-                job_name: 'sse-gateway-test-job'
+                api.subscribe('job', function () {
+                    expect('Should not have received this event').toBe();
+                }, {
+                    job_name: 'xxxxx'
+                });
+    
+                api.subscribe('job', function () {
+                    // Wait a sec to give time for the unexpected event to arrive.
+                    // It shouldn't arrive, but if it does, we throw an error. 
+                    setTimeout(function() {
+                        api.disconnect();
+                        done();
+                    }, 500);
+                }, {
+                    job_name: 'sse-gateway-test-job'
+                });
             });
         });
     }, 300000);


### PR DESCRIPTION
[JENKINS-35137](https://issues.jenkins-ci.org/browse/JENKINS-35137)

__TODO__

- [x] Fix bug and testing with a local proxy.
- [x] More manual testing with nginx or other.
- [x] Release HPI plugin.
- [x] Publish 0.0.3 of the client API.
