### PR TITLE
[JENKINS-36829] - empty rootURL incorrectly handled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/sse-gateway",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Client API for the Jenkins SSE Gateway plugin. Browser UI push events from Jenkins.",
   "main": "src/main/js/index.js",
   "files": [

--- a/src/main/js/sse-client.js
+++ b/src/main/js/sse-client.js
@@ -67,12 +67,13 @@ function scheduleDoConfigure(delay) {
 }
 function discoverJenkinsUrl() {
     jenkinsUrl = jsModules.getRootURL();
-
-    if (!jenkinsUrl || jenkinsUrl.length < 1) {
-        throw new Error('Invalid jenkinsUrl argument ' + jenkinsUrl);
-    }
-    if (jenkinsUrl.charAt(jenkinsUrl.length - 1) !== '/') {
-        jenkinsUrl += '/';
+    if (!jenkinsUrl) {
+        jenkinsUrl = '';
+    } else {
+        // only in tests, this is suffixed ...
+        while (jenkinsUrl.charAt(jenkinsUrl.length - 1) === '/') {
+            jenkinsUrl = jenkinsUrl.substring(0, jenkinsUrl.length - 1);
+        }
     }
 }
 
@@ -106,11 +107,10 @@ exports.connect = function (clientId, onConnect) {
         // TODO: Need to add browser poly-fills for stuff like this
         // See https://github.com/remy/polyfills/blob/master/EventSource.js
     } else {
-        var connectUrl = jenkinsUrl + 'sse-gateway/connect?clientId='
+        var connectUrl = jenkinsUrl + '/sse-gateway/connect?clientId='
                                     + encodeURIComponent(clientId);
-
         ajax.get(connectUrl, function () {
-            var listenUrl = jenkinsUrl + 'sse-gateway/listen/' + encodeURIComponent(clientId);
+            var listenUrl = jenkinsUrl + '/sse-gateway/listen/' + encodeURIComponent(clientId);
             var EventSource = window.EventSource;
             var source = new EventSource(listenUrl);
 
@@ -338,7 +338,7 @@ function doConfigure() {
         // open the SSE channel + send the jenkins session info.
         scheduleDoConfigure(100);
     } else {
-        var configureUrl = jenkinsUrl + 'sse-gateway/configure?batchId=' + configurationBatchId;
+        var configureUrl = jenkinsUrl + '/sse-gateway/configure?batchId=' + configurationBatchId;
 
         LOGGER.debug('Sending notification configuration request for configuration batch '
             + configurationBatchId + '.', configurationQueue);

--- a/src/test/js/sse-plugin-no-filter-ispec.js
+++ b/src/test/js/sse-plugin-no-filter-ispec.js
@@ -16,7 +16,7 @@ describe("sse plugin integration tests - subscribe and unsubscribe - no filters"
 
             function runBuild() {
                 var ajax = jsTest.requireSrcModule('ajax');
-                ajax.post(undefined, sseClient.jenkinsUrl + 'job/sse-gateway-test-job/build', jenkinsSessionInfo);
+                ajax.post(undefined, sseClient.jenkinsUrl + '/job/sse-gateway-test-job/build', jenkinsSessionInfo);
             }
 
             sseClient.connect('sse-client-123', function(jenkinsSession) {

--- a/src/test/js/sse-plugin-with-filter-ispec.js
+++ b/src/test/js/sse-plugin-with-filter-ispec.js
@@ -16,7 +16,7 @@ describe("sse plugin integration tests - with filters", function () {
                 var ajax = jsTest.requireSrcModule('ajax');
                 
                 // Once connected to the SSE Gateway, fire off a build of the sample job
-                ajax.post(undefined, sseClient.jenkinsUrl + 'job/sse-gateway-test-job/build', jenkinsSessionInfo);
+                ajax.post(undefined, sseClient.jenkinsUrl + '/job/sse-gateway-test-job/build', jenkinsSessionInfo);
 
                 sseClient.subscribe('job', function () {
                     expect('Should not have received this event').toBe();


### PR DESCRIPTION
On `ci.blueocean.io` there were inconsistencies in how URLs were handled, in particular the empty root URL was causing some issues. sse should also allow an empty root url, as Jenkins is typically `'/jenkins'` or `''`, if it's run at the root context (which is normal). This should fix an issue where sse would not work with normal Jenkins for this reason and align handling of these across the app.

NOTE: tests seem to be getting a URL which *does* end in a slash, unlike running Jenkins normally, so there's a bit to handle that.

Related to: https://github.com/jenkinsci/blueocean-plugin/pull/368

@reviewbybees esp. @tfennelly 