### PR TITLE
[JENKINS-36238] Store and Forward

### DIFF
--- a/headless-client.js
+++ b/headless-client.js
@@ -17,7 +17,9 @@ if (!global.window.EventSource) {
 
 var client = require('./src/main/js/sse-client');
 
-// exec configs immediately i.e. no delay for batching up.
-client.DEFAULT_BATCH_CONFIG_DELAY = 0;
+client.configure({
+    batchConfigDelay: 0, // exec batch configs immediately i.e. no delay for batching up.
+    sendSessionId: true  // maintain sessions with the backend via jsessionid
+});
 
 module.exports = client;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/sse-gateway",
-  "version": "0.0.7-beta1",
+  "version": "0.0.7-beta2",
   "description": "Client API for the Jenkins SSE Gateway plugin. Browser UI push events from Jenkins.",
   "main": "src/main/js/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/sse-gateway",
-  "version": "0.0.7-beta2",
+  "version": "0.0.7",
   "description": "Client API for the Jenkins SSE Gateway plugin. Browser UI push events from Jenkins.",
   "main": "src/main/js/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/sse-gateway",
-  "version": "0.0.6",
+  "version": "0.0.7-beta1",
   "description": "Client API for the Jenkins SSE Gateway plugin. Browser UI push events from Jenkins.",
   "main": "src/main/js/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@jenkins-cd/js-builder": "0.0.35",
     "@jenkins-cd/js-test": "^1.1.2",
     "gulp": "^3.9.1",
+    "http-proxy": "^1.14.0",
     "wait-until-promise": "^1.0.0"
   },
   "dependencies": {

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>pubsub-light</artifactId>
-      <version>1.3-SNAPSHOT</version>
+      <version>1.3</version>
     </dependency>
     
     <!-- Test deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>pubsub-light</artifactId>
-      <version>1.2</version>
+      <version>1.3-SNAPSHOT</version>
     </dependency>
     
     <!-- Test deps -->

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
@@ -97,7 +97,7 @@ public class Endpoint extends CrumbExclusion implements RootAction {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null) {
             try {
-                EventHistoryStore.setHistoryRoot(new File(jenkins.getRootDir(), "sse-event-store"));
+                EventHistoryStore.setHistoryRoot(new File(jenkins.getRootDir(), "/logs/sse-events"));
                 EventHistoryStore.enableAutoDeleteOnExpire();
             } catch (IOException e) {
                 LOGGER.log(Level.SEVERE, "Unexpected error setting EventHistoryStore event history root dir.", e);

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
@@ -143,7 +143,11 @@ public class Endpoint extends CrumbExclusion implements RootAction {
         }
         
         response.setStatus(HttpServletResponse.SC_OK);
-        return HttpResponses.okJSON(); 
+        
+        JSONObject responseData = new JSONObject();
+        responseData.put("jsessionid", session.getId());
+        
+        return HttpResponses.okJSON(responseData); 
     }
     
     @RequirePOST
@@ -230,7 +234,12 @@ public class Endpoint extends CrumbExclusion implements RootAction {
                 
                 if (requestedResource.startsWith(SSE_LISTEN_URL_PREFIX)) {
                     HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
-                    String clientId = requestedResource.substring(SSE_LISTEN_URL_PREFIX.length());
+                    String[] clientTokens = requestedResource.substring(SSE_LISTEN_URL_PREFIX.length()).split(";");
+                    String clientId = clientTokens[0];
+                    
+                    // If there's a second token it would be the jsessionid for 
+                    // when we're using a headless client. Not needed here though,
+                    // so just stripping out the clientId part.
                     
                     clientId = URLDecoder.decode(clientId, "UTF-8");
                     EventDispatcherFactory.start(clientId, httpServletRequest, httpServletResponse);

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
@@ -39,6 +39,8 @@ import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
 import org.jenkins.pubsub.Message;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Channel event message history store.
@@ -48,6 +50,7 @@ import org.jenkins.pubsub.Message;
  * 
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
+@Restricted(NoExternalUse.class)
 public final class EventHistoryStore {
 
     private static final Logger LOGGER = Logger.getLogger(EventHistoryStore.class.getName());

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.ssegateway;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
+import org.jenkins.pubsub.Message;
+
+/**
+ * Channel event message history store.
+ * <p>
+ * Currently stores event history in files on disk, purging them
+ * as they go "stale" (after they expire).
+ * 
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class EventHistoryStore {
+
+    private static final Logger LOGGER = Logger.getLogger(EventHistoryStore.class.getName());
+    
+    private static File historyRoot;
+    private static long expiresAfter = (1000 * 60 * 3); // default of 3 minutes
+    private static Map<String, File> channelDirs = new ConcurrentHashMap<>();
+
+    static void setHistoryRoot(@Nonnull File historyRoot) throws IOException {
+        if (!historyRoot.exists()) {
+            if (!historyRoot.mkdirs()) {
+                throw new IOException(String.format("Unexpected error creating historyRoot dir %s. Check permissions etc.", historyRoot.getAbsolutePath()));
+            }
+        }
+        EventHistoryStore.historyRoot = historyRoot;
+    }
+
+    static void setExpiryMillis(long expiresAfterMillis) {
+        EventHistoryStore.expiresAfter = expiresAfterMillis;
+    }
+
+    public static void store(@Nonnull Message message) {
+        try {
+            String channelName = message.getChannelName();
+            String eventUUID = message.getEventUUID();
+            File channelDir = getChannelDir(channelName);
+            File eventFile = new File(channelDir, eventUUID + ".json");
+        
+            FileUtils.writeStringToFile(eventFile, message.toJSON(), "UTF-8");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Unexpected error persisting EventHistoryStore entry file.", e);
+        }
+    }
+    
+    public static String getChannelEvent(@Nonnull String channelName, @Nonnull String eventUUID) throws IOException {
+        File channelDir = getChannelDir(channelName);
+        File eventFile = new File(channelDir, eventUUID + ".json");
+        
+        if (eventFile.exists()) {
+            return FileUtils.readFileToString(eventFile, "UTF-8");
+        } else {
+            return null;
+        }
+    }
+    
+    static int getChannelEventCount(@Nonnull String channelName) throws IOException {
+        Path dirPath = Paths.get(getChannelDir(channelName).toURI());
+        int count = 0;
+
+        try (final DirectoryStream<Path> dirStream = Files.newDirectoryStream(dirPath)) {
+            for (final Path entry : dirStream) {
+                count++;
+            }
+        }
+        
+        return count;
+    }
+
+    /**
+     * Delete all history.
+     */
+    static void deleteAllHistory() throws IOException {
+        assertHistoryRootSet();
+        deleteAllFilesInDir(EventHistoryStore.historyRoot, null);
+    }
+
+    /**
+     * Delete all stale history (events that have expired).
+     */
+    static void deleteStaleHistory() throws IOException {
+        assertHistoryRootSet();
+        long olderThan = System.currentTimeMillis() - expiresAfter;
+        deleteAllFilesInDir(EventHistoryStore.historyRoot, olderThan);
+    }
+
+    static File getChannelDir(@Nonnull String channelName) throws IOException {
+        assertHistoryRootSet();
+
+        File channelDir = channelDirs.get(channelName);
+        if (channelDir == null) {
+            channelDir = new File(historyRoot, channelName);
+            channelDirs.put(channelName, channelDir);
+        }
+        if (!channelDir.exists()) {
+            if (!channelDir.mkdirs()) {
+                throw new IOException(String.format("Unexpected error creating channel event log dir %s.", channelDir.getAbsolutePath()));
+            }
+        }
+        
+        return channelDir;
+    }
+    
+    private static void deleteAllFilesInDir(File dir, Long olderThan) throws IOException {
+        Path dirPath = Paths.get(dir.toURI());
+        
+        try (final DirectoryStream<Path> dirStream = Files.newDirectoryStream(dirPath)) {
+            for (final Path entry : dirStream) {
+                File file = entry.toFile();
+                if (file.isDirectory()) {
+                    deleteAllFilesInDir(file, olderThan);
+                }
+                if (olderThan == null || file.lastModified() < olderThan) {
+                    if (!file.delete()) {
+                        LOGGER.log(Level.SEVERE, "Error deleting file " + file.getAbsolutePath());
+                    }
+                }
+            }
+        }
+    }
+
+    private static void assertHistoryRootSet() {
+        if (historyRoot == null) {
+            throw new IllegalStateException("'historyRoot' not set. Check for earlier initialization errors.");
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
@@ -48,7 +48,7 @@ import org.jenkins.pubsub.Message;
  * 
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class EventHistoryStore {
+public final class EventHistoryStore {
 
     private static final Logger LOGGER = Logger.getLogger(EventHistoryStore.class.getName());
     

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/Util.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/Util.java
@@ -73,7 +73,7 @@ public class Util {
         if (Functions.getIsUnitTest()) {
             isTestEnv = true;
         } else {
-            isTestEnv = new File("./target/.jenkins_test").exists();
+            isTestEnv = new File("./target/classes/" + Util.class.getName().replace(".", "/") + ".class").exists();
         }
         
         return isTestEnv;

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcherFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcherFactory.java
@@ -103,6 +103,9 @@ public class EventDispatcherFactory {
             
             dispatcher.dispatchEvent("open", openData.toString());
             
+            // Run the retry process in case this is a reconnect.
+            dispatcher.processRetries();
+            
             return dispatcher;
         } catch (Exception e) {
             throw new IllegalStateException("Unexpected Exception.", e);

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/SSEChannel.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/SSEChannel.java
@@ -52,5 +52,6 @@ public interface SSEChannel {
         sse_subs_dispatcher_inst,
         sse_subs_channel_name,
         sse_subs_filter,
+        sse_dispatch_retry,
     }
 }

--- a/src/main/js/sse-client.js
+++ b/src/main/js/sse-client.js
@@ -130,6 +130,10 @@ exports.connect = function (clientId, onConnect) {
                     notifyConfigQueueListeners(configureInfo.batchId);
                 }
             }, false);
+            source.addEventListener('reload', function (e) {
+                LOGGER.debug('SSE channel "reload" event received. Reloading page now.', e);
+                window.location.reload(true);
+            }, false);
 
             // Add any listeners that have been requested to be added.
             for (var i = 0; i < eventSourceListenerQueue.length; i++) {

--- a/src/main/js/sse-client.js
+++ b/src/main/js/sse-client.js
@@ -107,6 +107,25 @@ exports.connect = function (clientId, onConnect) {
         /* eslint-enable */
     }
 
+    // If the browser supports HTML5 sessionStorage, then lets append a tab specific
+    // random ID to the client ID. This allows us to cleanly connect to a backend session,
+    // but to do it on a per tab basis i.e. reloading from the same tab reconnects that tab
+    // to the same backend dispatcher but allows each tab to have their own dispatcher,
+    // avoiding wierdness when multiple tabs are open to the same "clientId".
+    if (window.sessionStorage) {
+        var storeKey = 'jenkins-sse-gateway-client-' + clientId;
+        var tabClientId = window.sessionStorage.getItem(storeKey);
+
+        /* eslint-disable */
+        if (tabClientId) {
+            clientId = tabClientId;
+        } else {
+            clientId += '-' + generateTabId();
+            window.sessionStorage.setItem(storeKey, clientId);
+        }
+        /* eslint-enable */
+    }
+
     if (!jenkinsUrl) {
         discoverJenkinsUrl();
     }
@@ -376,4 +395,13 @@ function doConfigure() {
 
         resetConfigQueue();
     }
+}
+
+/**
+ * Generate a random "enough" string from the current time in
+ * millis + a random generated number string.
+ * @returns {string}
+ */
+function generateTabId() {
+    return (new Date().getTime()) + '-' + (Math.random() + 1).toString(36).substring(7);
 }

--- a/src/test/java/org/jenkinsci/plugins/ssegateway/EventHistoryStoreTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ssegateway/EventHistoryStoreTest.java
@@ -1,0 +1,99 @@
+package org.jenkinsci.plugins.ssegateway;
+
+import net.sf.json.JSONObject;
+import org.jenkins.pubsub.EventProps;
+import org.jenkins.pubsub.SimpleMessage;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class EventHistoryStoreTest {
+    
+    private static final String CHANNEL_NAME = "job";
+    private static int IOTA = 0;
+
+    private File historyRoot = new File("./target/historyRoot");
+    
+    @Before
+    public void setup() throws IOException {
+        EventHistoryStore.setHistoryRoot(historyRoot);
+        EventHistoryStore.setExpiryMillis(3000); // a 3s history window ... anything older than that would be "stale"
+        EventHistoryStore.deleteAllHistory();
+    }
+
+    @Test
+    public void test_store_count_delete() throws Exception {
+        Assert.assertEquals(0, EventHistoryStore.getChannelEventCount("job"));
+        storeMessages(15, 100);
+        Assert.assertEquals(15, EventHistoryStore.getChannelEventCount("job"));
+        
+        // delete and check count again
+        EventHistoryStore.deleteAllHistory();
+        Assert.assertEquals(0, EventHistoryStore.getChannelEventCount("job"));
+        storeMessages(15, 100);
+        Assert.assertEquals(15, EventHistoryStore.getChannelEventCount("job"));
+        EventHistoryStore.deleteAllHistory();
+        Assert.assertEquals(0, EventHistoryStore.getChannelEventCount("job"));
+    }
+
+    @Test
+    public void test_delete_stale_events() throws Exception {
+        EventHistoryStore.deleteAllHistory();
+        Assert.assertEquals(0, EventHistoryStore.getChannelEventCount("job"));
+        
+        // Store 6 events, each 1 second apart.
+        storeMessages(6, 1000);
+        
+        // sleep for split, just to move the window a little more.
+        Thread.sleep(200);
+        
+        // The "History Window" was set to 3 seconds in the @Before,
+        // so if we delete stale events now, we should delete at least
+        // some of those files, but not them all.
+        Assert.assertEquals(6, EventHistoryStore.getChannelEventCount("job"));
+        EventHistoryStore.deleteStaleHistory();
+        Assert.assertTrue(EventHistoryStore.getChannelEventCount("job") > 0);
+        Assert.assertTrue(EventHistoryStore.getChannelEventCount("job") < 6);
+        
+        // sleep for 6 seconds now, run the delete again and make sure
+        // the rest of the files are deleted because they should all be stale
+        // by then.
+        Thread.sleep(6000);
+        EventHistoryStore.deleteStaleHistory();
+        Assert.assertEquals(0, EventHistoryStore.getChannelEventCount("job"));
+    }
+
+    @Test
+    public void test_get_event() throws Exception {
+        SimpleMessage message = createMessage();
+        
+        EventHistoryStore.store(message);
+        
+        String eventAsString = EventHistoryStore.getChannelEvent("job", message.getEventUUID());
+        Assert.assertNotNull(eventAsString);
+        JSONObject eventAsJSON = JSONObject.fromObject(eventAsString);
+        Assert.assertEquals(message.getEventUUID(), eventAsJSON.getString(EventProps.Jenkins.jenkins_event_uuid.name()));
+    }
+    
+    private void storeMessages(int numMessages, long timeGap) throws Exception {
+        for (int i = 0; i < numMessages; i++) {
+            if (timeGap > 0) {
+                Thread.sleep(timeGap);
+            }
+            EventHistoryStore.store(createMessage());
+        }
+    }
+
+    private SimpleMessage createMessage() {
+        return new SimpleMessage().setChannelName(CHANNEL_NAME)
+                .setEventName("test-event")
+                .set("timestamp", Long.toString(System.currentTimeMillis()))
+                .set("messageNum", Integer.toString(IOTA++));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/ssegateway/SSEPluginIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ssegateway/SSEPluginIntegrationTest.java
@@ -69,4 +69,16 @@ public class SSEPluginIntegrationTest {
 
         gulpRunner.runIntegrationSpec("sse-plugin-with-filter");
     }
+    
+    @Test
+    public void test_store_and_forward() throws TaskRunnerException, IOException {
+        // Create a job. We will trigger a build of the job inside
+        // sse-plugin-store-and-forward.js (the integration test). That build execution
+        // should trigger events to the event subscribers in the test.
+        jenkins.createFreeStyleProject("sse-gateway-test-job");
+        
+        GulpRunner gulpRunner = new GulpRunner(jenkins);
+
+        gulpRunner.runIntegrationSpec("sse-plugin-store-and-forward");
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/ssegateway/WaitTimer.java
+++ b/src/test/java/org/jenkinsci/plugins/ssegateway/WaitTimer.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.ssegateway;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class WaitTimer {
+
+    private final long startedAt;
+
+    public WaitTimer() {
+        this.startedAt = System.currentTimeMillis();
+    }
+    
+    public void waitUntil(long timeMillis) {
+        long waitUntil = this.startedAt + timeMillis; 
+        
+        while (System.currentTimeMillis() < waitUntil) {
+            try {
+                Thread.sleep(0, 1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/test/node/GulpRunner.java
+++ b/src/test/java/org/jenkinsci/test/node/GulpRunner.java
@@ -63,10 +63,6 @@ public class GulpRunner {
         this.jenkinsRule = jenkinsRule;
     }
     
-    public void run() throws TaskRunnerException {
-        run("");
-    }
-    
     public void run(String command) throws TaskRunnerException {
         FrontendPluginFactory frontendPluginFactory = new FrontendPluginFactory(workDir, workDir);
         Map<String, String> env = new HashMap<>();

--- a/src/test/js/httpproxy.js
+++ b/src/test/js/httpproxy.js
@@ -1,0 +1,6 @@
+var httpProxy = require('http-proxy');
+var port = process.argv[2];
+ 
+httpProxy.createProxyServer({target:'http://localhost:' + port}).listen(18080);
+console.log('*** Proxying port 18080 to localhost:' + port);
+process.send({started: true});

--- a/src/test/js/sse-plugin-store-and-forward-ispec.js
+++ b/src/test/js/sse-plugin-store-and-forward-ispec.js
@@ -1,0 +1,137 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Integration test.
+ * <p>
+ * Run from Java (via GulpRunner) with a running Jenkins (via JenkinsRule).
+ */
+
+var jsTest = require('@jenkins-cd/js-test');
+var url = require('url');
+
+describe("sse plugin integration tests - ", function () {
+
+    it("- store and forward", function (done) {
+        
+        //
+        // The gist of what happend in tis test...
+        //
+        // The jenkins instance is running as normal from the enclosing junit test class.
+        // In here then, we launch a http-proxy and connect the SSE client under test
+        // through the http-proxy. Then, we kill the proxy, which causes the sse client to
+        // lose it's connection to the server. Then, we fire off a build while the 
+        // connection is lost. This should cause the dispatcher (on the server side) to
+        // fail to push the SSE events, which should result in them being added to the
+        // retry queue in the dispatcher. Then, when we restart the proxy, the sse client
+        // should auto-reconnect and the backlog of missed events should arrive into the
+        // client. If that happens ... the test passes :)
+        //
+        
+        var jenkinsUrl = process.env.JENKINS_URL;
+        var parsedJenkinsUrl = url.parse(jenkinsUrl);
+        var jenkinsPort = parsedJenkinsUrl.port;
+        var content = '<html><head data-rooturl="@JENKINS_URL@" data-resurl="@JENKINS_URL@/static/908d75c1" data-adjuncturl="@JENKINS_URL@/adjuncts/908d75c1"></head><body></body></html>'
+            .replace('@JENKINS_URL@', 'http://localhost:18080/jenkins/');
+        
+        jsTest.onPage(function() {
+            var proxy;
+
+            // Launching the http-proxy in a separate process completely because
+            // it's easier to "kill" it that way. Yes, we could embed the proxy here
+            // but then it's not possible to kill it as part of the test.
+            function startProxy(onStart) {
+                var childProcess = require('child_process');
+                proxy = childProcess.fork('./src/test/js/httpproxy.js', [jenkinsPort.toString()], { stdio: 'inherit' });
+                proxy.on('message', function (message) {
+                    if (message.started && onStart) {
+                        onStart();
+                    }
+                });
+            }
+            function stopProxy(onStop) {
+                proxy.on('close', function() {
+                    if (onStop) {
+                        onStop();
+                    }
+                });
+                proxy.kill('SIGHUP');
+            }
+            
+            startProxy(function() {
+                console.log('** proxy started');
+                var sseClient = require('../../../headless-client');
+                sseClient.connect('sse-client-123', function(jenkinsSessionInfo) {
+                    function build(jenkinsSessionInfo) {
+                        var ajax = jsTest.requireSrcModule('ajax');
+                        ajax.post(undefined, jenkinsUrl + 'job/sse-gateway-test-job/build', jenkinsSessionInfo);
+                    }
+                
+                    var eventRetryCount = 0;
+                    sseClient.subscribe({
+                        channelName: 'job',
+                        onSubscribed: function() {
+                            // Once subscribed to the job channel, kill the proxy.
+                            // Wait for a moment before doing this however because
+                            // the configure request might not yet be fully completed.
+                            setTimeout(function() {
+                                stopProxy(function() {
+                                    console.log('** proxy stopped.');
+
+                                    // Now lets fire off a build of the sample job
+                                    build(jenkinsSessionInfo);
+
+                                    // After a few seconds, lets restart the proxy.
+                                    // Once we do that, the events we missed while the 
+                                    // connection was lost (when the proxy was down)
+                                    // should come through in the onEvent method (see below).
+                                    setTimeout(function () {
+                                        console.log('** Restarting the proxy.');
+                                        startProxy();
+                                    }, 10000);
+                                });
+                            }, 1000);
+                        },
+                        onEvent: function(event) {
+                            if (event.sse_dispatch_retry) {
+                                eventRetryCount++;
+                            }
+                            if (event.jenkins_event === 'job_run_ended') {
+                                // Make sure we got all of the events and
+                                // not just the last one, and that at least
+                                // some of them were retry events.
+                                expect(eventRetryCount > 1).toBe(true);
+                                
+                                // We're done !!!
+                                sseClient.disconnect();
+                                stopProxy();
+                                done();
+                            }
+                        }
+                    });
+                });
+            });
+        }, content);
+    }, 90000);
+});

--- a/src/test/js/sse-plugin-with-filter-ispec.js
+++ b/src/test/js/sse-plugin-with-filter-ispec.js
@@ -25,8 +25,9 @@ describe("sse plugin integration tests - with filters", function () {
                 });
     
                 sseClient.subscribe('job', function () {
-                    // Wait a sec to give time for the unexpected event to arrive.
-                    // It shouldn't arrive, but if it does, we throw an error. 
+                    // Wait a sec to give time for the unexpected event to
+                    // arrive (see previous subscribe to job 'xxxxx'). It 
+                    // shouldn't arrive, but if it does, we throw an error. 
                     setTimeout(function() {
                         sseClient.disconnect();
                         done();
@@ -36,5 +37,5 @@ describe("sse plugin integration tests - with filters", function () {
                 });
             });
         });
-    }, 300000);
+    }, 60000);
 });


### PR DESCRIPTION
See [JENKINS-36238](https://issues.jenkins-ci.org/browse/JENKINS-36238)

Store and forwarding of events on client disconnect. 

Depends on https://github.com/jenkinsci/pubsub-light-module/pull/3

- [x] Implement store and forward of events while `EventDispatcher` connection to client is dead.
- [x] Implement automated unit tests.
- [x] Implement automated integration tests. Done using the headless SSE client. We could do more via the ATH and a real browser.