### PR TITLE
[FIX JENKINS-42196] Eliminate overly-eager SSE ping request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/sse-gateway",
-  "version": "0.0.18",
+  "version": "0.0.19-tf-JENKINS-42196-1",
   "description": "Client API for the Jenkins SSE Gateway plugin. Browser UI push events from Jenkins.",
   "main": "src/main/js/index.js",
   "files": [


### PR DESCRIPTION
# Description

See [JENKINS-42196](https://issues.jenkins-ci.org/browse/JENKINS-42196).

To test ... open the browser dev console. You should no longer see the `/ping` requests every ~30 seconds.