### PR TITLE
Quiet a superfluous warning which crops up during restarts

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
@@ -212,7 +212,7 @@ public abstract class EventDispatcher implements Serializable {
                 );
                 return true;
             } else {
-                LOGGER.log(Level.FINE, "Invalid SSE unsubscribe configuration. No active subscription for channel: " + channelName));
+                LOGGER.log(Level.FINE, "Invalid SSE unsubscribe configuration. No active subscription for channel: " + channelName);
             }
         } else {
             LOGGER.log(Level.SEVERE, String.format("Invalid SSE unsubscribe configuration. '%s' not specified.", EventProps.Jenkins.jenkins_channel));

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
@@ -212,7 +212,7 @@ public abstract class EventDispatcher implements Serializable {
                 );
                 return true;
             } else {
-                LOGGER.log(Level.WARNING, "Invalid SSE unsubscribe configuration. No active subscription matching filter: ");
+                LOGGER.log(Level.FINE, "Invalid SSE unsubscribe configuration. No active subscription matching filter: ");
             }
         } else {
             LOGGER.log(Level.SEVERE, String.format("Invalid SSE unsubscribe configuration. '%s' not specified.", EventProps.Jenkins.jenkins_channel));

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
@@ -212,7 +212,7 @@ public abstract class EventDispatcher implements Serializable {
                 );
                 return true;
             } else {
-                LOGGER.log(Level.FINE, "Invalid SSE unsubscribe configuration. No active subscription matching filter: ");
+                LOGGER.log(Level.FINE, "Invalid SSE unsubscribe configuration. No active subscription for channel: " + channelName));
             }
         } else {
             LOGGER.log(Level.SEVERE, String.format("Invalid SSE unsubscribe configuration. '%s' not specified.", EventProps.Jenkins.jenkins_channel));


### PR DESCRIPTION
Similar to behavior #21

Basically when an instance is restarting, there might be clients out where which seem to send an unsubscribe after a naster restart, causing this not-actionable warning to be emitted

Seen in Code Valet [here](https://canary.codevalet.io/issue/343374247)