### PR TITLE
[JENKINS-52123] Adjust sse-gateway to the now configurable location for tasks logging

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
@@ -109,13 +109,13 @@ public class Endpoint extends CrumbExclusion implements RootAction {
      * @return the root directory for logs.
      */
     private File getHistoryDirectory(Jenkins jenkins) {
-        File jenkinsLogsDir = new File(jenkins.getRootDir(), "/logs");
-
         final String overriddenLogsRoot = System.getProperty("hudson.triggers.SafeTimerTask.logsTargetDir");
-        if (overriddenLogsRoot != null) {
-            jenkinsLogsDir = new File(overriddenLogsRoot);
+
+        if (overriddenLogsRoot == null) {
+            return new File(jenkins.getRootDir(), "/logs/sse-events");
+        } else {
+            return new File(overriddenLogsRoot, "sse-events");
         }
-        return new File(jenkinsLogsDir, "sse-events");
     }
 
     @Override


### PR DESCRIPTION
Since 2.114, logs location is configurable, and so logs can be elsewhere than <rootDir>/logs.
Tested manually.

# Description

See [JENKINS-52123](https://issues.jenkins-ci.org/browse/JENKINS-52123).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
