### PR TITLE
Fix memory leak of EventDispatcher (retry queue plus EventDispatcher objects)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
@@ -136,11 +136,11 @@ public class Endpoint extends CrumbExclusion implements RootAction {
     @Restricted(DoNotUse.class) // Web only
     public HttpResponse doConnect(StaplerRequest request, StaplerResponse response) throws IOException {
         String clientId = request.getParameter("clientId");
-        
+
         if (clientId == null) {
             throw new IOException("No 'clientId' parameter specified in connect request.");
         }
-        
+
         HttpSession session = request.getSession();
         EventDispatcher dispatcher = EventDispatcherFactory.getDispatcher(clientId, session);
         

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
@@ -72,8 +72,10 @@ public abstract class EventDispatcher implements Serializable {
     private volatile boolean isRetryLoopActive = false;
 
     // set lifetime for retry events - default 5min - 300 sec - 300000 msec
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings("MS_SHOULD_BE_FINAL")
     public static /* not final */ long RETRY_QUEUE_EVENT_LIFETIME = Integer.getInteger(EventDispatcher.class.getName() + ".RETRY_QUEUE_EVENT_LIFETIME", 5*60) * 1000;
     // set delay for retry loop - default 250ms
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings("MS_SHOULD_BE_FINAL")
     public static /* not final */ long RETRY_QUEUE_PROCESSING_DELAY = Integer.getInteger(EventDispatcher.class.getName() + ".RETRY_QUEUE_PROCESSING_DELAY", 250);
 
     private String id = null;
@@ -86,6 +88,7 @@ public abstract class EventDispatcher implements Serializable {
     private long timestamp_dispatchEventOK = System.currentTimeMillis();
 
     // set timeout for unsubscribe if last successful dispatchEvent call is older than this timeout  - default: 4 hrs - 240 min - 14400 sec - 14400000 msec
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings("MS_SHOULD_BE_FINAL")
     public static /* not final */ long TIMEOUT_DISPATCHERFAIL = Integer.getInteger(EventDispatcher.class.getName() + ".TIMEOUT_DISPATCHERFAIL", 4*60*60) * 1000;
 
     // Lists of events that need to be retried on the next reconnect.
@@ -110,7 +113,7 @@ public abstract class EventDispatcher implements Serializable {
 
     public final String getId() {
         if (id == null) {
-            throw new IllegalStateException("Call to getId before the ID ewas set.");
+            throw new IllegalStateException("Call to getId before the ID was set.");
         }
         return id;
     }
@@ -422,6 +425,10 @@ public abstract class EventDispatcher implements Serializable {
                     retryQueue.remove();
                     retry = retryQueue.peek();
                 }
+
+            } catch (Exception e) {
+                LOGGER.log(Level.FINE, String.format("EventDispatcher (%s) - Error dispatching retry event to SSE channel. Write failed.", this));
+                return;
 
             } finally {
                 if (!retryQueue.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
@@ -69,11 +69,25 @@ public abstract class EventDispatcher implements Serializable {
     public static final String SESSION_SYNC_OBJ = "org.jenkinsci.plugins.ssegateway.sse.session.sync";
     private static final Logger LOGGER = Logger.getLogger(EventDispatcher.class.getName());
 
+    private volatile boolean isRetryLoopActive = false;
+
+    // set lifetime for retry events - default 5min - 300 sec - 300000 msec
+    public static /* not final */ long RETRY_QUEUE_EVENT_LIFETIME = Integer.getInteger(EventDispatcher.class.getName() + ".RETRY_QUEUE_EVENT_LIFETIME", 5*60) * 1000;
+    // set delay for retry loop - default 250ms
+    public static /* not final */ long RETRY_QUEUE_PROCESSING_DELAY = Integer.getInteger(EventDispatcher.class.getName() + ".RETRY_QUEUE_PROCESSING_DELAY", 250);
+
     private String id = null;
     private final transient PubsubBus bus;
     private final transient Authentication authentication;
     private transient Map<EventFilter, ChannelSubscriber> subscribers = new CopyOnWriteMap.Hash<>();
-    
+
+    // timestamp of last successfull dispatchEvent call
+    // default to current time to avoid timeout if first call fails
+    private long timestamp_dispatchEventOK = System.currentTimeMillis();
+
+    // set timeout for unsubscribe if last successful dispatchEvent call is older than this timeout  - default: 4 hrs - 240 min - 14400 sec - 14400000 msec
+    public static /* not final */ long TIMEOUT_DISPATCHERFAIL = Integer.getInteger(EventDispatcher.class.getName() + ".TIMEOUT_DISPATCHERFAIL", 4*60*60) * 1000;
+
     // Lists of events that need to be retried on the next reconnect.
     private transient Queue<Retry> retryQueue = new ConcurrentLinkedQueue<>();
     
@@ -111,20 +125,46 @@ public abstract class EventDispatcher implements Serializable {
     }
 
     /**
+     * Checks if last successful dispatchEvent is older than TIMEOUT_DISPATCHERFAIL
+     * if yes: suspect the dispatcher counterpart is dead
+     *          - clear retry queue
+     *          - remove all subscriptions
+     *
+     * @param step current step for log message
+     */
+    private void checkDispatcherFailTimeout(String step) {
+        long t_curr = System.currentTimeMillis();
+        long t_diff = t_curr - timestamp_dispatchEventOK;
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, String.format("SSE dispatcher %s %s fail - %d - %d - %d", this, step, t_curr, t_diff, TIMEOUT_DISPATCHERFAIL));
+        }
+        if (t_diff > TIMEOUT_DISPATCHERFAIL) {
+            LOGGER.log(Level.FINE, String.format("SSE dispatcher %s %s fail - timediff > TIMEOUT_DISPATCHERFAIL", this, step));
+            retryQueue.clear();
+            this.unsubscribeAll();
+        }
+    }
+
+    /**
      * Writes a message to {@link HttpServletResponse}
      *
+     * @param name event-name
+     * @param data event-data
+     * @throws IOException io-exception
+     * @throws ServletException servlet-exception
      * @return
      *      false if the response is not writable
      */
     public synchronized boolean dispatchEvent(String name, String data) throws IOException, ServletException {
         HttpServletResponse response = getResponse();
-        
+
         if (response == null) {
+            checkDispatcherFailTimeout("response");
             // The SSE channel is not connected or is reconnecting after timeout.
             // Event will go to retry queue.
             return false;
         }
-        
+
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.log(Level.FINEST, String.format("SSE dispatcher %s sending event: %s", this, data));
         }
@@ -132,6 +172,7 @@ public abstract class EventDispatcher implements Serializable {
         PrintWriter writer = response.getWriter();
         
         if (writer.checkError()) {
+            checkDispatcherFailTimeout("writer.checkError");
             return false;
         }
         
@@ -142,8 +183,19 @@ public abstract class EventDispatcher implements Serializable {
             writer.write("data: " + data + "\n");
         }
         writer.write("\n");
-        
-        return (!writer.checkError());
+
+        boolean writerStatus = writer.checkError();
+
+        if (!writerStatus) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, String.format("SSE dispatcher %s writer ok - %d", this, System.currentTimeMillis()));
+            }
+            timestamp_dispatchEventOK = System.currentTimeMillis();
+        } else {
+            checkDispatcherFailTimeout("writer.write");
+        }
+
+        return (!writerStatus);
     }
     
     public void stop() {
@@ -233,13 +285,20 @@ public abstract class EventDispatcher implements Serializable {
     }
 
     private void scheduleRetryQueueProcessing(long delay) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, String.format("EventDispatcher (%s) - scheduleRetryQueueProcessing(%d)", this, delay));
+        }
         if (delay > 0) {
-            new Timer().schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    processRetries();
-                }
-            }, delay);
+            try {
+                new Timer().schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        processRetries();
+                    }
+                }, delay);
+            } catch (Exception e) {
+                LOGGER.log(Level.INFO, String.format("EventDispatcher (%s) - scheduleRetryQueueProcessing - Error creating timer.", this));
+            }
         } else {
             processRetries();
         }
@@ -276,70 +335,108 @@ public abstract class EventDispatcher implements Serializable {
     }
     
     private void addToRetryQueue(@Nonnull Message message) {
+        // check retry queue is empty
+        //  -> we are adding the first element
+        //  -> start the retryqueue timer
+        boolean isFirstEvent = retryQueue.isEmpty();
         if (!retryQueue.add(new Retry(message))) {
             // Unable to add to the queue. Lets just tell the client
             // that it needs to reload the page.
             dispatchReload();
+        } else {
+            // Event was added to the queue.
+            // If it was the first event -> start the retry loop timer
+            if (isFirstEvent) {
+                scheduleRetryQueueProcessing(RETRY_QUEUE_PROCESSING_DELAY);
+            }
         }
     }
 
     synchronized void processRetries() {
-        Retry retry = retryQueue.peek();
-        
-        try {
-            while (retry != null) {
-                try {
-                    String eventJSON = EventHistoryStore.getChannelEvent(retry.channelName, retry.eventUUID);
+        if (!isRetryLoopActive) {
+            isRetryLoopActive = true;
+            Retry retry = retryQueue.peek();
 
-                    if (eventJSON == null) {
-                        // The event is not in the store. This can be simply because the event has
-                        // not yet arrived at the store and been stored. It might need another
-                        // moment or two to get there.
-                        if (!retry.needsMoreTimeToLandInStore()) {
-                            // Something's gone wrong. The event should be in the store by now. 
-                            // Lets tell the client that it needs to do a full page reload. Not much
-                            // else can be done at this stage.
-                            dispatchReload(); // This clears the queue too.
-                            return;
-                        } else {
-                            // The event should be in the store (not expired, so would not 
-                            // have been deleted). Only explanation is that it has not yet
-                            // landed there. Let's pause the retry process
-                            // for a moment and retry again in the hope that the event
-                            // eventually lands there. Exiting here will schedule a new run
-                            // of this retry process (see finally block below).
-                            return;
+            if (retry != null) {
+                long ctime = System.currentTimeMillis();
+                long retry_age = (ctime - retry.timestamp);
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, String.format("EventDispatcher (%s) - timestamp: %d - current: %d - age: %d", this, retry.timestamp, ctime, retry_age));
+                }
+                // check time of oldest retry envent
+                if (retry_age > RETRY_QUEUE_EVENT_LIFETIME) {
+                    // oldest event has timed out - remove all events from retry queue
+                    LOGGER.log(Level.FINE, String.format("EventDispatcher (%s) processRetries - clear retryQueue", this));
+                    retryQueue.clear();
+                    retry = null;
+                }
+            }
+
+            try {
+                while (retry != null) {
+                    try {
+                        String eventJSON = EventHistoryStore.getChannelEvent(retry.channelName, retry.eventUUID);
+
+                        if (eventJSON == null) {
+                            // The event is not in the store. This can be simply because the event has
+                            // not yet arrived at the store and been stored. It might need another
+                            // moment or two to get there.
+                            if (!retry.needsMoreTimeToLandInStore()) {
+                                // Something's gone wrong. The event should be in the store by now.
+                                // Lets tell the client that it needs to do a full page reload. Not much
+                                // else can be done at this stage.
+                                dispatchReload(); // This clears the queue too.
+                                return;
+                            } else {
+                                // The event should be in the store (not expired, so would not
+                                // have been deleted). Only explanation is that it has not yet
+                                // landed there. Let's pause the retry process
+                                // for a moment and retry again in the hope that the event
+                                // eventually lands there. Exiting here will schedule a new run
+                                // of this retry process (see finally block below).
+                                return;
+                            }
                         }
-                    }
-                    
-                    if (Util.isTestEnv()) {
-                        JSONObject eventJSONObj = JSONObject.fromObject(eventJSON);
-                        eventJSONObj.put(SSEChannel.EventProps.sse_dispatch_retry.name(), "true");
-                        eventJSON = eventJSONObj.toString();
+
+                        if (Util.isTestEnv()) {
+                            JSONObject eventJSONObj = JSONObject.fromObject(eventJSON);
+                            eventJSONObj.put(SSEChannel.EventProps.sse_dispatch_retry.name(), "true");
+                            eventJSON = eventJSONObj.toString();
+                        }
+
+                        if (LOGGER.isLoggable(Level.FINEST)) {
+                            LOGGER.log(Level.FINEST, String.format("EventDispatcher (%s) - retry event: %s", this, eventJSON));
+                        }
+                        if (!dispatchEvent(retry.channelName, eventJSON)) {
+                            LOGGER.log(Level.FINE, String.format("EventDispatcher (%s) - Error dispatching retry event to SSE channel. Write failed.", this));
+                            return;
+                        } else if (LOGGER.isLoggable(Level.FINEST)) {
+                            LOGGER.log(Level.FINEST, "EventDispatcher ({0}) - Dispatched retry event to SSE channel. Event {1}.", new Object[]{this, eventJSON});
+                        }
+                    } catch (Exception e) {
+                        LOGGER.log(Level.FINE, String.format("EventDispatcher (%s) - Error dispatching retry event to SSE channel. Write failed.", this));
+                        return;
                     }
 
-                    if (!dispatchEvent(retry.channelName, eventJSON)) {
-                        LOGGER.log(Level.FINE, String.format("Error dispatching retry event to SSE channel. Write failed. Dispatcher %s.", this));
-                        return;
-                    } else if (LOGGER.isLoggable(Level.FINEST)) {
-                        LOGGER.log(Level.FINEST, "Dispatched retry event to SSE channel. Dispatcher {0}. Event {1}.", new Object[] {this, eventJSON});
-                    }
-                } catch (Exception e) {
-                    LOGGER.log(Level.FINE, String.format("Error dispatching retry event to SSE channel. Write failed. Dispatcher %s.", this), e);
-                    return;
+                    // Only remove from the queue once successfully dispatched.
+                    retryQueue.remove();
+                    retry = retryQueue.peek();
                 }
 
-                // Only remove from the queue once successfully dispatched.
-                retryQueue.remove();
-                retry = retryQueue.peek();
+            } finally {
+                if (!retryQueue.isEmpty()) {
+                    // For some reason the processing has exited prematurely.
+                    // Schedule it to run again. We must clear this ASAP.
+                    scheduleRetryQueueProcessing(RETRY_QUEUE_PROCESSING_DELAY);
+                }
+                isRetryLoopActive = false;
             }
-
-        } finally {
-            if (!retryQueue.isEmpty()) {
-                // For some reason the processing has exited prematurely.
-                // Schedule it to run again. We must clear this ASAP.
-                scheduleRetryQueueProcessing(100);
-            }
+            // i dont know why - but in some strange cases
+            // this set of isRetryLoopActive to false is necessary
+            // in my opinon the statement inside the finally should be
+            // sufficient - but without this second false i had some
+            // endless loops
+            isRetryLoopActive = false;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcherFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcherFactory.java
@@ -75,7 +75,7 @@ public class EventDispatcherFactory {
                         "SSE client reconnects will not work - probably fine if running in non-browser/test mode.", clientId, session.getId()));
                 dispatcher = EventDispatcherFactory.newDispatcher(clientId, session);
             }
-            
+
             dispatcher.start(request, response);
             dispatcher.setDefaultHeaders();
 
@@ -83,11 +83,11 @@ public class EventDispatcherFactory {
 
             openData.put("dispatcherId", dispatcher.getId());
             openData.put("dispatcherInst", System.identityHashCode(dispatcher));
-            
+
             if (Util.isTestEnv()) {
                 openData.putAll(Util.getSessionInfo(session));
 
-                // Crumb needed for testing because we use it to fire off some 
+                // Crumb needed for testing because we use it to fire off some
                 // test builds via the POST API.
                 Jenkins jenkins = Jenkins.getInstance();
                 CrumbIssuer crumbIssuer = jenkins.getCrumbIssuer();
@@ -100,12 +100,12 @@ public class EventDispatcherFactory {
                     LOGGER.log(Level.WARNING, "No CrumbIssuer on Jenkins instance. Some POSTs might not work.");
                 }
             }
-            
+
             dispatcher.dispatchEvent("open", openData.toString());
-            
+
             // Run the retry process in case this is a reconnect.
             dispatcher.processRetries();
-            
+
             return dispatcher;
         } catch (Exception e) {
             throw new IllegalStateException("Unexpected Exception.", e);

--- a/src/test/java/org/jenkinsci/plugins/ssegateway/SSEPluginIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ssegateway/SSEPluginIntegrationTest.java
@@ -45,7 +45,7 @@ public class SSEPluginIntegrationTest {
     public void setupRealm() {
         jenkins.jenkins.setSecurityRealm(jenkins.createDummySecurityRealm());
     }
-    
+
     @Test
     public void test_no_filter() throws TaskRunnerException, IOException {
         // Create a job. We will trigger a build of the job inside
@@ -57,7 +57,7 @@ public class SSEPluginIntegrationTest {
 
         gulpRunner.runIntegrationSpec("sse-plugin-no-filter");
     }
-    
+
     @Test
     public void test_with_filter() throws TaskRunnerException, IOException {
         // Create a job. We will trigger a build of the job inside
@@ -69,7 +69,7 @@ public class SSEPluginIntegrationTest {
 
         gulpRunner.runIntegrationSpec("sse-plugin-with-filter");
     }
-    
+
     @Test
     public void test_store_and_forward() throws TaskRunnerException, IOException {
         // Create a job. We will trigger a build of the job inside
@@ -81,4 +81,24 @@ public class SSEPluginIntegrationTest {
 
         gulpRunner.runIntegrationSpec("sse-plugin-store-and-forward");
     }
+
+    @Test
+    public void test_retryqueue_timeout() throws TaskRunnerException, IOException {
+        // Create a job. We will trigger a build of the job inside
+        // sse-plugin-retryqueue-timeout.js (the integration test). That build execution
+        // should trigger events to the event subscribers in the test.
+        jenkins.createFreeStyleProject("sse-gateway-test-job");
+
+        // set lifetime for retry events - default 300 sec
+        // in the integratation test we wait 20000ms until restarting the proxy
+        // -> all queued event should be removed from the queue
+        org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_EVENT_LIFETIME = 15;
+        // set delay for retry loop - default 100ms
+        org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_PROCESSING_DELAY = 500;
+
+        GulpRunner gulpRunner = new GulpRunner(jenkins);
+
+        gulpRunner.runIntegrationSpec("sse-plugin-retryqueue-timeout");
+    }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/ssegateway/SSEPluginIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ssegateway/SSEPluginIntegrationTest.java
@@ -89,16 +89,23 @@ public class SSEPluginIntegrationTest {
         // should trigger events to the event subscribers in the test.
         jenkins.createFreeStyleProject("sse-gateway-test-job");
 
-        // set lifetime for retry events - default 300 sec
-        // in the integratation test we wait 20000ms until restarting the proxy
+        // set lifetime for retry events to 15 sec - default is 300 sec
+        // in the integration test waiting time is 20000ms until restarting the proxy
         // -> all queued event should be removed from the queue
+        long saveEventLifetime = org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_EVENT_LIFETIME;
         org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_EVENT_LIFETIME = 15;
-        // set delay for retry loop - default 100ms
+
+        // set delay for retry loop = 500ms - default is 100ms
+        long saveProcessingDelay = org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_PROCESSING_DELAY;
         org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_PROCESSING_DELAY = 500;
 
         GulpRunner gulpRunner = new GulpRunner(jenkins);
 
         gulpRunner.runIntegrationSpec("sse-plugin-retryqueue-timeout");
+
+        // restore saved values
+        org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_EVENT_LIFETIME = saveEventLifetime;
+        org.jenkinsci.plugins.ssegateway.sse.EventDispatcher.RETRY_QUEUE_PROCESSING_DELAY = saveProcessingDelay;
     }
 
 }

--- a/src/test/js/sse-plugin-no-filter-ispec.js
+++ b/src/test/js/sse-plugin-no-filter-ispec.js
@@ -93,7 +93,12 @@ describe("sse plugin integration tests - subscribe and unsubscribe - no filters"
                             expect(jobSubsCalled).toBe(1);
 
                             sseConnection.disconnect();
-                            done();
+                            // give jenkins some time to send remaining events
+                            // e.g. 'job_run_queue_task_complete'
+                            setTimeout(function () {
+                                console.log('** done.');
+                                done();
+                            }, 1000);
                         });
                     }
                 });

--- a/src/test/js/sse-plugin-with-filter-ispec.js
+++ b/src/test/js/sse-plugin-with-filter-ispec.js
@@ -8,7 +8,7 @@ var jsTest = require('./jsTest');
 var ajax = require('../../main/js/ajax');
 
 describe("sse plugin integration tests - with filters", function () {
-   
+
     it("- test build receives events", function (done) {
 
         jsTest.onPage(function() {
@@ -31,7 +31,10 @@ describe("sse plugin integration tests - with filters", function () {
                     // shouldn't arrive, but if it does, we throw an error. 
                     setTimeout(function() {
                         sseConnection.disconnect();
-                        done();
+                        setTimeout(function () {
+                            console.log('** done.');
+                            done();
+                        }, 1000);
                     }, 500);
                 }, {
                     job_name: 'sse-gateway-test-job'


### PR DESCRIPTION
# Description

See [JENKINS-51057](https://issues.jenkins-ci.org/browse/JENKINS-51057).

over the last weeks we checked the pull request from 'sternr' fixing the EventDispatcher.Retry classes.
see pull request #27 'Fix memory leak of EventDispatcher.Retry classes'
i made some changes/extensions to his fix:
- replace retry counter by timeout
- add second timeout to remove outdated EventDispatchers

the two timeouts can be set by:

RETRY_QUEUE_EVENT_LIFETIME
default: 5 min
after this timeout all events from the retry queue will be removed (replaces the retry counter from 'sternr's implementation

TIMEOUT_DISPATCHERFAIL
default: 4 hrs
if some dispatcher fails to call his counterpart for more than this timeout the dispatcher will be removed (unsubscribed)

also the delay for the retry queue can be set by:
RETRY_QUEUE_PROCESSING_DELAY
default: 250 ms


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
