### PR TITLE
Give meaningful names to threads created by the plugin

### DIFF
--- a/load-test/src/main/java/org/jenkinsci/plugins/ssegateway/load/SSELoadPage.java
+++ b/load-test/src/main/java/org/jenkinsci/plugins/ssegateway/load/SSELoadPage.java
@@ -54,7 +54,7 @@ public class SSELoadPage implements RootAction {
         final String intervalMillisParam = request.getParameter("intervalMillis");
 
         if (numMessagesParam != null && intervalMillisParam != null) {
-            new Thread() {
+            new Thread("SSELoadPage.doFireEvents") {
                 @Override
                 public void run() {
                     final int numMessages = new Integer(numMessagesParam);

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
@@ -250,7 +250,7 @@ public final class EventHistoryStore {
         long taskSchedule = expiresAfter / 3;
         autoExpireTimer = new Timer("EventHistoryStore.autoExpireTimer");
         autoExpireTimer.schedule(new DeleteStaleHistoryTask(), taskSchedule, taskSchedule);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> disableAutoDeleteOnExpire()));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> disableAutoDeleteOnExpire(), "EventHistoryStore.disableAutoExpireTimer"));
     }
     
     public synchronized static void disableAutoDeleteOnExpire() {

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
@@ -248,7 +248,7 @@ public final class EventHistoryStore {
         // every 10 seconds i.e. in that case, events are never left lying around
         // for more than 10 seconds past their expiration.
         long taskSchedule = expiresAfter / 3;
-        autoExpireTimer = new Timer();
+        autoExpireTimer = new Timer("EventHistoryStore.autoExpireTimer");
         autoExpireTimer.schedule(new DeleteStaleHistoryTask(), taskSchedule, taskSchedule);
         Runtime.getRuntime().addShutdownHook(new Thread(() -> disableAutoDeleteOnExpire()));
     }

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/SubscriptionConfigQueue.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/SubscriptionConfigQueue.java
@@ -92,7 +92,7 @@ final class SubscriptionConfigQueue {
                 } finally {
                     queue = null;
                 }
-            }
+            }, "SubscriptionConfigQueue.start"
         ).start();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcher.java
@@ -293,7 +293,7 @@ public abstract class EventDispatcher implements Serializable {
         }
         if (delay > 0) {
             try {
-                new Timer().schedule( new TimerTask() {
+                new Timer("EventDispatcher.retryProcessor").schedule( new TimerTask() {
                     @Override
                     public void run() {
                         processRetries();


### PR DESCRIPTION
# Description

See [JENKINS-58684](https://issues.jenkins-ci.org/browse/JENKINS-58684), where some users suspect that #30 ([JENKINS-51057](https://issues.jenkins-ci.org/browse/JENKINS-51057)) might have introduced a thread leak.

I don't know what this plugin does, so I can't really comment on that issue, but creating timer threads and raw threads directly without giving them meaningful names makes it much more difficult to identify what plugin is causing issues (because the generated name is just something like "Timer-57"). This PR just gives names to all of the timer threads and threads, usually of the form (`Class.method` or `Class.field`), so that users will be more easily able to determine if this plugin really is the cause of [JENKINS-58684](https://issues.jenkins-ci.org/browse/JENKINS-58684).

No tests added, because this change should not affect any actual functionality of the plugin.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

CC @olamy 
