### PR TITLE
Switch to using json.stringify instead of JSON.stringify which gets polluted by prototype

### DIFF
--- a/src/main/js/SSEConnection.js
+++ b/src/main/js/SSEConnection.js
@@ -552,7 +552,7 @@ SSEConnection.prototype = {
 
             this.configurationQueue.dispatcherId = sessionInfo.dispatcherId;
             // clone the config, just in case of bad change later.
-            var configurationQueue = JSON.parse(JSON.stringify(this.configurationQueue));
+            var configurationQueue = JSON.parse(json.stringify(this.configurationQueue));
             var sseConnection = this;
 
             ajax.post(configurationQueue, configureUrl, sessionInfo, function (data, http) {


### PR DESCRIPTION
Was trying to hook up sse-gateway to html5-notifications-plugin to reduce all the custom code.

Wasn't able to connect to the sse gateway, it looks like double encoding

Tracked down to a use of the raw JSON.stringify, instead of the "fixed" version