### PR TITLE
Transmit the session ID as cookie instead of part of URL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/Endpoint.java
@@ -231,6 +231,8 @@ public class Endpoint extends CrumbExclusion implements RootAction {
                 
                 if (requestedResource.startsWith(SSE_LISTEN_URL_PREFIX)) {
                     HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+                    // This part is kept in case someone is sending the jsessionid with the ;
+                    // but this is no longer the case for the tests of this plugin
                     String[] clientTokens = requestedResource.substring(SSE_LISTEN_URL_PREFIX.length()).split(";");
                     String clientId = clientTokens[0];
                     

--- a/src/main/js/SSEConnection.js
+++ b/src/main/js/SSEConnection.js
@@ -151,15 +151,16 @@ SSEConnection.prototype = {
                 var listenUrl = sseConnection.jenkinsUrl + '/sse-gateway/listen/'
                     + encodeURIComponent(tabClientId);
 
+                var options = undefined;
                 if (sseConnection.configuration.sendSessionId) {
                     // Sending the jsessionid helps headless clients to maintain
                     // the session with the backend.
                     var jsessionid = response.data.jsessionid;
-                    listenUrl += ';jsessionid=' + jsessionid;
+                    options = {headers: {Cookie: 'jsessionid=' + jsessionid}}
                 }
 
                 var EventSource = window.EventSource;
-                var source = new EventSource(listenUrl);
+                var source = new EventSource(listenUrl, options);
 
                 source.addEventListener('open', function (e) {
                     LOGGER.debug('SSE channel "open" event.', e);


### PR DESCRIPTION
The code is only used for the testing.

Similar approach as the one used in BO: https://github.com/jenkinsci/blueocean-plugin/commit/fb75e524bc70b861d1819544e476b14f27ab43fa#diff-7c4e088720f8fe8962618f0947472140L101-R121