### PR TITLE
Do not bundle commons-io in this plugin's HPI file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pubsub-light</artifactId>
       <version>1.13</version>
@@ -83,12 +78,17 @@
       <artifactId>frontend-plugin-core</artifactId>
       <version>1.7.6</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
+      <exclusions>
+        <!-- We want to pick these up as dependencies of Jenkins core in provided scope -->
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
`commons-io` is a dependency provided by Jenkins core. Having an explicit dependency on it in this plugin in compile scope causes it to be bundled inside of this plugin's HPI:

```
$ jar -tf target/sse-gateway.hpi 
META-INF/
META-INF/MANIFEST.MF
WEB-INF/
WEB-INF/lib/
WEB-INF/licenses.xml
WEB-INF/lib/sse-gateway.jar
WEB-INF/lib/commons-io-2.4.jar  # BAD!
META-INF/maven/
META-INF/maven/org.jenkins-ci.plugins/
META-INF/maven/org.jenkins-ci.plugins/sse-gateway/
META-INF/maven/org.jenkins-ci.plugins/sse-gateway/pom.xml
META-INF/maven/org.jenkins-ci.plugins/sse-gateway/pom.properties
```

This is pointless, because at runtime, class loading in plugins delegates to Jenkins core (at least by default, see [here](https://jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/) for details), so any JARs in the main Jenkins WAR will take precedence over JARs bundled in plugin HPIs.

The fix here is to remove the explicit `commons-io` dependency so that we pick up the version from Jenkins core and do not bundle it in this plugin's HPI. Once we do that, we get an enforcer error because `frontend-plugin-core` also depends on `commons-io`, so we exclude the dependency from `frontend-maven-core` to use the version from Jenkins itself. We also go ahead and exclude the dependency on `commons-compress`, which doesn't cause any enforcer errors today, but might in the future.

Here are the contents of `sse-gateway.hpi` with the fix:

```
$ jar -tf target/sse-gateway.hpi 
META-INF/
META-INF/MANIFEST.MF
WEB-INF/
WEB-INF/lib/
WEB-INF/licenses.xml
WEB-INF/lib/sse-gateway.jar
META-INF/maven/
META-INF/maven/org.jenkins-ci.plugins/
META-INF/maven/org.jenkins-ci.plugins/sse-gateway/
META-INF/maven/org.jenkins-ci.plugins/sse-gateway/pom.xml
META-INF/maven/org.jenkins-ci.plugins/sse-gateway/pom.properties
```

I think it's better to exclude the dependencies from `frontend-plugin-core` instead of having explicit dependencies in provided scope or `dependencyManagement` entries, because we do not want other plugins to need to deal with enforcer issues with `commons-io` or `commons-compress`, and the proper versions of those components always depends on the version of Jenkins being used at runtime.