### PR TITLE
Remove unnecessary SpotBugs workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.45</version>
+    <version>4.51</version>
     <relativePath />
   </parent>
   <artifactId>sse-gateway</artifactId>
@@ -75,10 +75,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pubsub-light</artifactId>
       <version>1.17</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
     </dependency>
     
     <!-- Test deps -->

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
@@ -165,15 +165,9 @@ public final class EventHistoryStore {
     
     static long getChannelEventCount(@Nonnull String channelName) throws IOException {
         Path dirPath = Paths.get(getChannelDir(channelName).toURI());
-        try (DirectoryStream<Path> dirStream = createDirectoryStream( dirPath )) {
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(dirPath)) {
             return StreamSupport.stream( dirStream.spliterator(), false ).count();
         }
-    }
-
-    // because of this https://github.com/spotbugs/spotbugs/issues/756
-    // olamy: ridiculous to have to change code because of a tool...
-    private static @Nonnull DirectoryStream<Path> createDirectoryStream(Path dirPath) throws IOException {
-        return Files.newDirectoryStream(dirPath);
     }
 
     /**
@@ -218,7 +212,7 @@ public final class EventHistoryStore {
         if(!Files.exists(dirPath)){
             return;
         }
-        try (final DirectoryStream<Path> dirStream = createDirectoryStream(dirPath)) {
+        try (final DirectoryStream<Path> dirStream = Files.newDirectoryStream(dirPath)) {
             for (Path entry : dirStream) {
                 File file = entry.toFile();
                 if (file.isDirectory()) {


### PR DESCRIPTION
The workaround added for SpotBugs in #53 is no longer necessary as of recent versions of SpotBugs and can now be removed. CC @olamy 