### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/EventHistoryStore.java
@@ -23,8 +23,6 @@
  */
 package org.jenkinsci.plugins.ssegateway;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -38,6 +36,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.StreamSupport;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.security.ACL;
 import org.apache.commons.io.FileUtils;
@@ -73,7 +73,7 @@ public final class EventHistoryStore {
 
     @SuppressFBWarnings(value = "LI_LAZY_INIT_STATIC", 
                 justification = "internal class (marked @Restricted NoExternalUse + package private methods) - need it this way for testing.")
-    static void setHistoryRoot(@Nonnull File historyRoot) throws IOException {
+    static void setHistoryRoot(@NonNull File historyRoot) throws IOException {
         // In a non-test mode, we only allow setting of the historyRoot 
         // once (during plugin init - see Endpoint class).
         if (EventHistoryStore.historyRoot != null && !Util.isTestEnv()) {
@@ -114,7 +114,7 @@ public final class EventHistoryStore {
      * 
      * @param message The message instance to store.
      */
-    static void store(@Nonnull Message message) {
+    static void store(@NonNull Message message) {
         try {
             String channelName = message.getChannelName();
             String eventUUID = message.getEventUUID();
@@ -138,7 +138,7 @@ public final class EventHistoryStore {
         }
     }
     
-    public static @CheckForNull String getChannelEvent(@Nonnull String channelName, @Nonnull String eventUUID) throws IOException {
+    public static @CheckForNull String getChannelEvent(@NonNull String channelName, @NonNull String eventUUID) throws IOException {
         File channelDir = getChannelDir(channelName);
         File eventFile = new File(channelDir, eventUUID + ".json");
         
@@ -149,21 +149,21 @@ public final class EventHistoryStore {
         }
     }
     
-    public static void onChannelSubscribe(@Nonnull String channelName) {
+    public static void onChannelSubscribe(@NonNull String channelName) {
         if (historyRoot == null) {
             return;
         }
         getChannelSubsCounter(channelName).incrementAndGet();
     }
     
-    public static void onChannelUnsubscribe(@Nonnull String channelName) {
+    public static void onChannelUnsubscribe(@NonNull String channelName) {
         if (historyRoot == null) {
             return;
         }
         getChannelSubsCounter(channelName).decrementAndGet();
     }
     
-    static long getChannelEventCount(@Nonnull String channelName) throws IOException {
+    static long getChannelEventCount(@NonNull String channelName) throws IOException {
         Path dirPath = Paths.get(getChannelDir(channelName).toURI());
         try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(dirPath)) {
             return StreamSupport.stream( dirStream.spliterator(), false ).count();
@@ -190,7 +190,7 @@ public final class EventHistoryStore {
         deleteAllFilesInDir(EventHistoryStore.historyRoot, olderThan);
     }
 
-    static File getChannelDir(@Nonnull String channelName) throws IOException {
+    static File getChannelDir(@NonNull String channelName) throws IOException {
         assertHistoryRootSet();
 
         File channelDir = channelDirs.get(channelName);
@@ -268,7 +268,7 @@ public final class EventHistoryStore {
         }
     }
     
-    private static AtomicInteger getChannelSubsCounter(@Nonnull String channelName) {
+    private static AtomicInteger getChannelSubsCounter(@NonNull String channelName) {
         AtomicInteger counter = channelSubsCounters.get(channelName);
         if (counter == null) {
             counter = newChannelSubsCounter(channelName);
@@ -276,7 +276,7 @@ public final class EventHistoryStore {
         return counter;
     }
 
-    private static synchronized AtomicInteger newChannelSubsCounter(@Nonnull String channelName) {
+    private static synchronized AtomicInteger newChannelSubsCounter(@NonNull String channelName) {
         AtomicInteger counter = channelSubsCounters.get(channelName);
         if (counter == null) {
             counter = new AtomicInteger(0);
@@ -315,7 +315,7 @@ public final class EventHistoryStore {
         }
 
         @Override
-        public void onMessage(@Nonnull Message message) {
+        public void onMessage(@NonNull Message message) {
             if (channelSubsCounter.get() > 0) {
                 store(message);
             }

--- a/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcherFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/ssegateway/sse/EventDispatcherFactory.java
@@ -32,8 +32,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -64,7 +64,7 @@ public class EventDispatcherFactory {
         }
     }
     
-    public static EventDispatcher start(@Nonnull String clientId, @Nonnull HttpServletRequest request, @Nonnull HttpServletResponse response) {
+    public static EventDispatcher start(@NonNull String clientId, @NonNull HttpServletRequest request, @NonNull HttpServletResponse response) {
         try {
             HttpSession session = request.getSession();
             EventDispatcher dispatcher = EventDispatcherFactory.getDispatcher(clientId, session);
@@ -118,7 +118,7 @@ public class EventDispatcherFactory {
      * @param session The {@link HttpSession}.
      * @return The session {@link EventDispatcher}s.
      */
-    public synchronized static Map<String, EventDispatcher> getDispatchers(@Nonnull HttpSession session) {
+    public synchronized static Map<String, EventDispatcher> getDispatchers(@NonNull HttpSession session) {
         Map<String, EventDispatcher> dispatchers = (Map<String, EventDispatcher>) session.getAttribute(DISPATCHER_SESSION_KEY);
         if (dispatchers == null) {
             dispatchers = new HashMap<>();
@@ -134,7 +134,7 @@ public class EventDispatcherFactory {
      * @param session The {@link HttpSession}.
      * @return The new {@link EventDispatcher} instance.
      */
-    public synchronized static EventDispatcher newDispatcher(@Nonnull String clientId, @Nonnull HttpSession session) {
+    public synchronized static EventDispatcher newDispatcher(@NonNull String clientId, @NonNull HttpSession session) {
         Map<String, EventDispatcher> dispatchers = getDispatchers(session);
         try {
             EventDispatcher dispatcher = runtimeClass.newInstance();
@@ -155,7 +155,7 @@ public class EventDispatcherFactory {
      * @param session The {@link HttpSession}.
      * @return The {@link EventDispatcher}, or {@code null} if no such dispatcher is known. 
      */
-    public static @CheckForNull EventDispatcher getDispatcher(@Nonnull String dispatcherId, @Nonnull HttpSession session) {
+    public static @CheckForNull EventDispatcher getDispatcher(@NonNull String dispatcherId, @NonNull HttpSession session) {
         Map<String, EventDispatcher> dispatchers = getDispatchers(session);
         return dispatchers.get(dispatcherId);
     }


### PR DESCRIPTION
# Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

Confirmed that automated tests pass on Linux with Java 21.

Behavior preserving transformation should not require any additional testing beyond test automation.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
